### PR TITLE
Restore the actual validation happening for the `#/definitions/*` types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
+  - "4"
+  - "6"
+  - "8"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "src/validator.js",
   "scripts": {
     "test": "mocha ./tests",
-    "posttest": "jshint ./src ./tests"
+    "posttest": "jshint ./src ./tests ./scripts"
   },
   "bin": {
     "json-validate": "./scripts/json-validate.js"

--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
   "author": "Maxim Gnatenko <mgnatenko@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "async": "^1.4.2",
+    "async": "^2.4.1",
     "request": "^2.61.0",
     "tv4": "^1.2.3",
-    "tv4-formats": "^1.0.1"
+    "tv4-formats": "^3.0.0"
   },
   "devDependencies": {
     "jshint": "^2.8.0",
-    "mocha": "^2.3.0",
-    "sinon": "^1.16.1"
+    "mocha": "^3.4.2",
+    "sinon": "^2.3.2"
   }
 }

--- a/scripts/json-validate.js
+++ b/scripts/json-validate.js
@@ -17,6 +17,7 @@ Usage:\n\
         async = require('async'),
         Validator = require('../src/validator.js'),
         typeId = process.argv[2],
+        schemaFileUrl = typeId.split("#")[0],
 
         readStdin = function (callback) {
             var data = '';
@@ -31,7 +32,7 @@ Usage:\n\
         };
 
     async.parallel({
-        validator: function (callback) { Validator.simple(typeId, callback); },
+        validator: function (callback) { Validator.simple(schemaFileUrl, callback); },
         json: readStdin
     }, function (err, results) {
 

--- a/scripts/json-validate.js
+++ b/scripts/json-validate.js
@@ -4,6 +4,7 @@
     'use strict';
 
     if (process.argv.length !== 3) {
+        /* jshint multistr:true */
         process.stdout.write('\n\
 This script validates JSON from stdin, using schema parameter\n\
 Usage:\n\
@@ -13,11 +14,10 @@ Usage:\n\
         process.exit(1);
     }
 
-    var request = require('request'),
-        async = require('async'),
+    var async = require('async'),
         Validator = require('../src/validator.js'),
         typeId = process.argv[2],
-        schemaFileUrl = typeId.split("#")[0],
+        schemaFileUrl = typeId.split('#')[0],
 
         readStdin = function (callback) {
             var data = '';
@@ -35,7 +35,6 @@ Usage:\n\
         validator: function (callback) { Validator.simple(schemaFileUrl, callback); },
         json: readStdin
     }, function (err, results) {
-
         if (err) {
             console.log('ERROR:', err);
         }
@@ -59,6 +58,5 @@ Usage:\n\
         ].join(' '));
 
         process.exit(1);
-
     });
 }());


### PR DESCRIPTION
Drop the fragment for the fetched schema URL

Looks like tv4 changed, and in versions ^1.1 it started treating the URL-s with
fragments differently, causing the following result:

```
$ echo '[]' | ./scripts/json-validate.js 'https://www.swisshotels.com/ota/schema#/definitions/availableHotel'
VALID.
```

`echo '{}'` would yield the same false-positive. Moreover, one could pass
anything in the `#` fragment of the type ID, and it'd still be reported as
`VALID.`

This change restores the actual validation happening for the `#/definitions/*`
types.
